### PR TITLE
Only show top left border when not in fullscreen

### DIFF
--- a/dots/firefox/chrome/content/inner-rounded.css
+++ b/dots/firefox/chrome/content/inner-rounded.css
@@ -1,7 +1,9 @@
 /* make borders from inner content rounded */
-#tabbrowser-tabpanels browser[type="content"] {
-	color-scheme: env(-moz-content-preferred-color-scheme);
-	border-top-left-radius: 16px;
+@media all and (display-mode: browser) {
+	#tabbrowser-tabpanels browser[type="content"] {
+		color-scheme: env(-moz-content-preferred-color-scheme);
+		border-top-left-radius: 16px;
+	}
 }
 
 /* comment this out for padding around the content */


### PR DESCRIPTION
The border would stay rounded when in full screen and this would cause that for instance when watching a video in fullscreen you could still see the border on the top left.

With this change it's possible to browse normally with the rounded border but change back to squared when needed.